### PR TITLE
feat(telegram): adds fault tolerance and polling to Ice Bear

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   MIX_ENV: test
+  TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
 
 jobs:
   dependencies:

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,5 +25,3 @@ bot_token = System.get_env("TELEGRAM_BOT_TOKEN")
 
 config :ice_bear,
   bot_token: bot_token
-
-import_config "test.secret.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,3 +20,10 @@ config :ice_bear, IceBearWeb.Endpoint,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+bot_token = System.get_env("TELEGRAM_BOT_TOKEN")
+
+config :ice_bear,
+  bot_token: bot_token
+
+import_config "test.secret.exs"

--- a/lib/ice_bear/application.ex
+++ b/lib/ice_bear/application.ex
@@ -16,7 +16,10 @@ defmodule IceBear.Application do
       # Start the Endpoint (http/https)
       IceBearWeb.Endpoint,
       # Start Finch Connection Pool.
-      IceBear.Telegram.Client.child_spec()
+      IceBear.Telegram.Client.child_spec(),
+      # Start the BotSupervisor that will start processes
+      # for the Bot & BotPolar.
+      IceBear.Telegram.BotSupervisor
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/ice_bear/telegram/bot.ex
+++ b/lib/ice_bear/telegram/bot.ex
@@ -5,6 +5,7 @@ defmodule IceBear.Telegram.Bot do
   use GenServer
   require Logger
 
+  alias Phoenix.PubSub
   alias IceBear.Telegram.Client, as: Telegram
 
   def start_link(opts) do
@@ -16,11 +17,21 @@ defmodule IceBear.Telegram.Bot do
     Logger.debug("----> IceBear.Telegram.Bot.init/1")
     {:ok, %{"id" => id, "username" => username}} = Telegram.get_me()
 
+    # Have Ice Bear subscribe to the message "ice_bear:<id>"
+    PubSub.subscribe(IceBear.PubSub, "ice_bear:#{id}")
+
     state = %{
       id: id,
       username: username
     }
 
     {:ok, state}
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    Logger.debug("----> IceBear.Telegram.Bot.handle_info/2")
+    Logger.info(inspect(msg))
+    {:noreply, state}
   end
 end

--- a/lib/ice_bear/telegram/bot.ex
+++ b/lib/ice_bear/telegram/bot.ex
@@ -1,0 +1,26 @@
+defmodule IceBear.Telegram.Bot do
+  @moduledoc """
+  Implementation details of Ice Bear.
+  """
+  use GenServer
+  require Logger
+
+  alias IceBear.Telegram.Client, as: Telegram
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, opts)
+  end
+
+  @impl true
+  def init(_opts) do
+    Logger.debug("----> IceBear.Telegram.Bot.init/1")
+    {:ok, %{"id" => id, "username" => username}} = Telegram.get_me()
+
+    state = %{
+      id: id,
+      username: username
+    }
+
+    {:ok, state}
+  end
+end

--- a/lib/ice_bear/telegram/bot.ex
+++ b/lib/ice_bear/telegram/bot.ex
@@ -7,10 +7,19 @@ defmodule IceBear.Telegram.Bot do
 
   alias Phoenix.PubSub
   alias IceBear.Telegram.Client, as: Telegram
+  import IceBear.Telegram.Commands, only: [command: 1]
+
+  ######################
+  # Client API
+  ######################
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, opts)
   end
+
+  ######################
+  # GenServer Callbacks
+  ######################
 
   @impl true
   def init(_opts) do
@@ -29,9 +38,39 @@ defmodule IceBear.Telegram.Bot do
   end
 
   @impl true
-  def handle_info(msg, state) do
+  def handle_info({:update, update}, state) do
     Logger.debug("----> IceBear.Telegram.Bot.handle_info/2")
-    Logger.info(inspect(msg))
+
+    update |> parse_response() |> handle_message(state)
+
     {:noreply, state}
+  end
+
+  def handle_message({_id, command}, _state) when command === "/create",
+    do: command([:create, %{}])
+
+  def handle_message({_id, command}, _state) when command === "/delete",
+    do: command([:delete, %{}])
+
+  def handle_message({_id, command}, _state) when command === "/read",
+    do: command([:read, %{}])
+
+  def handle_message({_id, command}, _state) when command === "/update",
+    do: command([:update, %{}])
+
+  def handle_message({id, text}, _state),
+    do: Telegram.send_message(id, "Huh? #{text} is not an option.")
+
+  ##################
+  # Module Utilities
+  ##################
+
+  defp parse_response(response) do
+    Logger.info("Response: #{inspect(response)}")
+
+    id = response["message"]["chat"]["id"]
+    text = response["message"]["text"]
+
+    {id, text}
   end
 end

--- a/lib/ice_bear/telegram/bot_polar.ex
+++ b/lib/ice_bear/telegram/bot_polar.ex
@@ -1,0 +1,27 @@
+defmodule IceBear.Telegram.BotPolar do
+  @moduledoc """
+  Polling service for Ice Bear to listen and receive updates from Telegram.
+  """
+  use GenServer
+  require Logger
+
+  import IceBear.Telegram.Client, except: [send_message: 2]
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, opts)
+  end
+
+  @impl true
+  def init(_opts) do
+    Logger.debug("----> IceBear.Telegram.BotPolar.init/1")
+    {:ok, %{"id" => id, "username" => username}} = get_me()
+
+    state = %{
+      id: id,
+      last_seen: -2,
+      username: username
+    }
+
+    {:ok, state}
+  end
+end

--- a/lib/ice_bear/telegram/bot_polar.ex
+++ b/lib/ice_bear/telegram/bot_polar.ex
@@ -8,9 +8,17 @@ defmodule IceBear.Telegram.BotPolar do
   alias Phoenix.PubSub
   import IceBear.Telegram.Client, except: [send_message: 2]
 
+  ######################
+  # Client API
+  ######################
+
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, opts)
   end
+
+  ######################
+  # GenServer Callbacks
+  ######################
 
   @impl true
   def init(_opts) do
@@ -63,6 +71,10 @@ defmodule IceBear.Telegram.BotPolar do
     next_loop()
     {:noreply, state}
   end
+
+  ##################
+  # Module Utilities
+  ##################
 
   defp next_loop do
     Process.send_after(self(), :start, 0)

--- a/lib/ice_bear/telegram/bot_supervisor.ex
+++ b/lib/ice_bear/telegram/bot_supervisor.ex
@@ -1,0 +1,17 @@
+defmodule IceBear.Telegram.BotSupervisor do
+  use Supervisor
+
+  def start_link(key) do
+    Supervisor.start_link(__MODULE__, key)
+  end
+
+  @impl true
+  def init(key) do
+    children = [
+      {IceBear.Telegram.Bot, key},
+      {IceBear.Telegram.BotPolar, key}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+end

--- a/lib/ice_bear/telegram/bot_supervisor.ex
+++ b/lib/ice_bear/telegram/bot_supervisor.ex
@@ -1,12 +1,26 @@
 defmodule IceBear.Telegram.BotSupervisor do
+  @moduledoc """
+  Supervisor for managing the Bot and BotPolar GenServers.
+  """
   use Supervisor
+  require Logger
+
+  ######################
+  # Client API
+  ######################
 
   def start_link(key) do
     Supervisor.start_link(__MODULE__, key)
   end
 
+  ######################
+  # Supervisor Callbacks
+  ######################
+
   @impl true
   def init(key) do
+    Logger.debug("----> IceBear.Telegram.BotSupervisor.init/1")
+
     children = [
       {IceBear.Telegram.Bot, key},
       {IceBear.Telegram.BotPolar, key}

--- a/lib/ice_bear/telegram/commands.ex
+++ b/lib/ice_bear/telegram/commands.ex
@@ -1,4 +1,14 @@
 defmodule IceBear.Telegram.Commands do
+  @moduledoc """
+  Module represents all the commands that Ice Bear can except and act on
+  that are built into his config on Telegram.
+
+  Commands:
+  - /create
+  - /delete
+  - /read
+  - /update
+  """
   require Logger
 
   def command([:create, opts]),

--- a/lib/ice_bear/telegram/commands.ex
+++ b/lib/ice_bear/telegram/commands.ex
@@ -1,0 +1,15 @@
+defmodule IceBear.Telegram.Commands do
+  require Logger
+
+  def command([:create, opts]),
+    do: Logger.info("----> IceBear.Telegram.Commands.command([:create, #{inspect(opts)}])")
+
+  def command([:delete, opts]),
+    do: Logger.info("----> IceBear.Telegram.Commands.command([:delete, #{inspect(opts)}])")
+
+  def command([:read, opts]),
+    do: Logger.info("----> IceBear.Telegram.Commands.command([:read, #{inspect(opts)}])")
+
+  def command([:update, opts]),
+    do: Logger.info("----> IceBear.Telegram.Commands.command([:update, #{inspect(opts)}])")
+end


### PR DESCRIPTION
## What does this PR do?

- adds `bot.ex` that acts as the implementation of Ice Bear.
- adds `bot_polar.ex` for polling the Telegram Bot API for messages sent to Ice Bear.
- adds `bot_supervisor.ex` for monitoring `bot` and `bot_polar` and restarting them if they fail.
- adds `commands.ex` for scaffolding out the commands Ice Bear will accept.